### PR TITLE
Gh actions

### DIFF
--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -1,0 +1,31 @@
+name: Nix Flake actions
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  nix-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v30
+      - id: set-matrix
+        name: Generate Nix Matrix
+        run: |
+          set -Eeu
+          matrix="$(nix eval --json '.#githubActions.matrix')"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  nix-build:
+    name: ${{ matrix.name }} (${{ matrix.system }})
+    needs: nix-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v30
+      - run: nix build -L '.#${{ matrix.attr }}'

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,13 @@
 {
-  inputs.nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+    nix-github-actions = {
+      url = "github:nix-community/nix-github-actions";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
 
-  outputs = { nixpkgs, self, ... }:
+  outputs = { nixpkgs, self, nix-github-actions, ... }:
     let
       systems = [ "x86_64-linux" "aarch64-linux" ];
 
@@ -80,5 +86,7 @@
         };
         default = aa-alias-manager;
       });
+
+      githubActions = nix-github-actions.lib.mkGithubMatrix { checks = self.packages; };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,6 @@
         default = aa-alias-manager;
       });
 
-      githubActions = nix-github-actions.lib.mkGithubMatrix { checks = self.packages; };
+      githubActions = nix-github-actions.lib.mkGithubMatrix { checks = nixpkgs.lib.getAttrs [ "x86_64-linux" ] self.packages; }; # todo: figure out testing on aarch64-linux
     };
 }


### PR DESCRIPTION
This adds github actions to build all packages exposed by the flake.
This catches:
- cargo hash mismatch
- the project not compiling
- nix not evaluating for whatever other reason

This does *not* prove correct functionality of aa-alias-manager.